### PR TITLE
Remove invalid images

### DIFF
--- a/src/constants/placeholderImage.js
+++ b/src/constants/placeholderImage.js
@@ -1,0 +1,2 @@
+export const placeholderImage =
+  'https://s3.amazonaws.com/launchlibrary/RocketImages/placeholder_320.png';

--- a/src/sagas/cache.js
+++ b/src/sagas/cache.js
@@ -1,6 +1,12 @@
+import { placeholderImage } from '../constants/placeholderImage';
+
 export function changeImageUrlWithCached(launches) {
   launches = JSON.parse(JSON.stringify(launches), (key, value) => {
     if (key === 'imageURL') {
+      const isValid = value.startsWith('http');
+      if (!isValid) {
+        return [placeholderImage, placeholderImage];
+      }
       try {
         const prePostUrl = value.split('_');
         const resEnding = prePostUrl[1].split('.');


### PR DESCRIPTION
Investigated why the tests had started to fail. It appeared to be a rocket image from the API that had the value "Array" instead of an actual URL. 